### PR TITLE
fix wrongly update conference settings when initiating a conference join

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,3 +1,5 @@
+import { ConferenceModes } from "src/api/types";
+
 export interface LoginCredential {
   name?: string;
   password?: string;
@@ -55,6 +57,12 @@ export interface AppSettings {
   sipUsername: string;
   sipPassword: string;
   sipDisplayName: string;
+}
+
+export interface ConferenceSettings {
+  mode: ConferenceModes;
+  tags: string;
+  speakOnlyTo: string;
 }
 
 export interface AdvancedAppSettings {

--- a/src/lib/SipSession.ts
+++ b/src/lib/SipSession.ts
@@ -65,7 +65,6 @@ export default class SipSession extends events.EventEmitter {
     this.#rtcSession.on(
       "accepted",
       ({ response }: { response: IncomingResponse }) => {
-        console.log("xquanluu");
         this.emit(SipConstants.SESSION_ANSWERED, {
           status: SipConstants.SESSION_ANSWERED,
           callSid: response.hasHeader("X-Call-Sid")

--- a/src/lib/SipSession.ts
+++ b/src/lib/SipSession.ts
@@ -65,6 +65,7 @@ export default class SipSession extends events.EventEmitter {
     this.#rtcSession.on(
       "accepted",
       ({ response }: { response: IncomingResponse }) => {
+        console.log("xquanluu");
         this.emit(SipConstants.SESSION_ANSWERED, {
           status: SipConstants.SESSION_ANSWERED,
           callSid: response.hasHeader("X-Call-Sid")

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -2,9 +2,26 @@ import {
   AdvancedAppSettings,
   AppSettings,
   CallHistory,
+  ConferenceSettings,
 } from "src/common/types";
 import { Buffer } from "buffer";
 
+// Conference settings
+const CONFERENCE_SETTINGS = "ConferenceSettingsKey";
+
+export const saveConferenceSettings = (settings: ConferenceSettings) => {
+  sessionStorage.setItem(CONFERENCE_SETTINGS, JSON.stringify(settings));
+};
+
+export const getConferenceSettings = (): ConferenceSettings => {
+  return JSON.parse(
+    sessionStorage.getItem(CONFERENCE_SETTINGS) || "{}"
+  ) as ConferenceSettings;
+};
+
+export const deleteConferenceSettings = () => {
+  sessionStorage.removeItem(CONFERENCE_SETTINGS);
+};
 // Settings
 const SETTINGS_KEY = "SettingsKey";
 

--- a/src/window/phone/index.tsx
+++ b/src/window/phone/index.tsx
@@ -114,6 +114,7 @@ export const Phone = ({
   );
   const [selectedConference, setSelectedConference] = useState("");
   const [callSid, setCallSid] = useState("");
+  const [showConference, setShowConference] = useState(false);
 
   const inputNumberRef = useRef(inputNumber);
   const sessionDirectionRef = useRef(sessionDirection);
@@ -154,6 +155,13 @@ export const Phone = ({
       clientGoOffline();
     }
     fetchRegisterUser();
+    getConferences()
+      .then(() => {
+        setShowConference(true);
+      })
+      .catch(() => {
+        setShowConference(false);
+      });
   }, [sipDomain, sipUsername, sipPassword, sipServerAddress, sipDisplayName]);
 
   useEffect(() => {
@@ -643,7 +651,7 @@ export const Phone = ({
                   }}
                 />
               )}
-              {registeredUser.allow_direct_app_calling && (
+              {registeredUser.allow_direct_app_calling && showConference && (
                 <IconButtonMenu
                   icon={<FontAwesomeIcon icon={faPeopleGroup} />}
                   tooltip="Join a conference"


### PR DESCRIPTION
Hi @davehorton here is PR for fixing issue when initiating new conference, the conference mode, tag, speakOnlyTo are wrongly set to empty value.


this also check if the conference endpoint is already supported in jambonz cluster to show conference button